### PR TITLE
Molecular2D example switch from CkVec to std::vector

### DIFF
--- a/doc/charisma/manual.rst
+++ b/doc/charisma/manual.rst
@@ -661,7 +661,7 @@ for the 6D array.
 
 .. code-block:: c++
 
-     void getIndex_cellpairs(CkVec<CkArrayIndex6D>& vec) {
+     void getIndex_cellpairs(std::vector<CkArrayIndex6D>& vec) {
        int i,j,k,l,m,n;
        for(i=0;i<N;i++)
          for(j=0;j<N;j++)

--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -2199,7 +2199,8 @@ PUP STL Container Objects
 If the variable is from the C++ Standard Template Library, you can
 include operator\ ``|``\ ’s for STL containers such as vector, map, set,
 list, pair, and string, templated on anything, by including the header
-“pup_stl.h”.
+“pup_stl.h” or <pup_stl.h>. This header should be placed in the .h or
+the .C/.cpp file in the project, and not in the .ci file.
 
 See ``examples/charm++/PUP/STLPUP``
 

--- a/examples/charm++/Molecular2D/Compute.C
+++ b/examples/charm++/Molecular2D/Compute.C
@@ -36,7 +36,7 @@ Compute::Compute() {
 Compute::Compute(CkMigrateMessage *msg) { }
   
 // Function to receive vector of particles
-void Compute::interact(CkVec<Particle> particles, int x, int y ) {
+void Compute::interact(std::vector<Particle> particles, int x, int y ) {
 
   int i;
 
@@ -61,10 +61,10 @@ void Compute::interact(CkVec<Particle> particles, int x, int y ) {
 }
 
 // Function to compute all the interactions between pairs of particles in two sets
-void Compute::interact(CkVec<Particle> &first, CkVec<Particle> &second){
+void Compute::interact(std::vector<Particle> &first, std::vector<Particle> &second){
   int i, j;
-  for(i = 0; i < first.length(); i++)
-    for(j = 0; j < second.length(); j++)
+  for(i = 0; i < first.size(); i++)
+    for(j = 0; j < second.size(); j++)
       interact(first[i], second[j]);
 }
 

--- a/examples/charm++/Molecular2D/Compute.h
+++ b/examples/charm++/Molecular2D/Compute.h
@@ -13,18 +13,18 @@
 class Compute : public CBase_Compute {
   private:
     int cellCount;  // to count the number of interact() calls
-    CkVec<Particle> bufferedParticles;
+    std::vector<Particle> bufferedParticles;
     int bufferedX;
     int bufferedY;
 
-    void interact(CkVec<Particle> &first, CkVec<Particle> &second);
+    void interact(std::vector<Particle> &first, std::vector<Particle> &second);
     void interact(Particle &first, Particle &second);
 
   public:
     Compute();
     Compute(CkMigrateMessage *msg);
 
-    void interact(CkVec<Particle> particles, int i, int j);
+    void interact(std::vector<Particle> particles, int i, int j);
 
 };
 

--- a/examples/charm++/Molecular2D/Patch.C
+++ b/examples/charm++/Molecular2D/Patch.C
@@ -177,15 +177,15 @@ void Patch::start() {
 }
 
 // Function to update forces coming from a compute
-void Patch::updateForces(CkVec<Particle> updates) {
+void Patch::updateForces(std::vector<Particle> updates) {
   int i, x, y, x1, y1;
-  CkVec<Particle> outgoing[NUM_NEIGHBORS];
+  std::vector<Particle> outgoing[NUM_NEIGHBORS];
 
   // incrementing the counter for receiving updates
   forceCount++;
 
   // updating force information
-  for(i = 0; i < updates.length(); i++){
+  for(i = 0; i < updates.size(); i++){
     particles[i].fx += updates[i].fx;
     particles[i].fy += updates[i].fy;
   }
@@ -202,11 +202,11 @@ void Patch::updateForces(CkVec<Particle> updates) {
     x = thisIndex.x;
     y = thisIndex.y;
 
-    for(i=0; i<particles.length(); i++) {
+    for(i=0; i<particles.size(); i++) {
       migrateToPatch(particles[i], x1, y1);
       if(x1 !=0 || y1!=0) {
 	outgoing[(x1+1)*NBRS_Y + (y1+1)].push_back(wrapAround(particles[i]));
-	particles.remove(i);
+	particles.erase(particles.begin() + i);
       }
     }
    
@@ -248,9 +248,9 @@ void Patch::checkNextStep(){
     stepCount++;
 
     // adding new elements
-    for (i = 0; i < incomingParticles.length(); i++)
+    for (i = 0; i < incomingParticles.size(); i++)
       particles.push_back(incomingParticles[i]);
-    incomingParticles.removeAll();
+    incomingParticles.clear();
 
     if (thisIndex.x==0 && thisIndex.y==0 && stepCount%10==0) {
       timer = CkWallTimer();
@@ -270,10 +270,10 @@ void Patch::checkNextStep(){
 
 // Function that receives a set of particles and updates the 
 // forces of them into the local set
-void Patch::updateParticles(CkVec<Particle> updates) {
+void Patch::updateParticles(std::vector<Particle> updates) {
   updateCount++;
 
-  for( int i=0; i < updates.length(); i++) {
+  for( int i=0; i < updates.size(); i++) {
     incomingParticles.push_back(updates[i]);
   }
 
@@ -291,7 +291,7 @@ void Patch::updateProperties() {
   int i;
   double xDisp, yDisp;
 	
-  for(i = 0; i < particles.length(); i++) {
+  for(i = 0; i < particles.size(); i++) {
     // applying kinetic equations
     particles[i].ax = particles[i].fx / DEFAULT_MASS;
     particles[i].ay = particles[i].fy / DEFAULT_MASS;
@@ -362,7 +362,7 @@ void Patch::requestNextFrame(liveVizRequestMsg *lvmsg) {
     for(int j=0; j<myWidthPx; ++j)
       color_pixel(intensity,myWidthPx,myHeightPx,j,i,0,0,0);	// black background
 
-  for (int i=0; i < particles.length(); i++ ) {
+  for (int i=0; i < particles.size(); i++ ) {
     int xpos = (int)((particles[i].x /(double) (patchSize*patchArrayDimX)) * wdes) - sx;
     int ypos = (int)((particles[i].y /(double) (patchSize*patchArrayDimY)) * hdes) - sy;
 
@@ -394,7 +394,7 @@ void Patch::print(){
   CkPrintf("*****************************************************\n");
   CkPrintf("Patch (%d, %d)\n", thisIndex.x, thisIndex.y);
 
-  for(i=0; i < particles.length(); i++)
+  for(i=0; i < particles.size(); i++)
     CkPrintf("Patch (%d,%d) %-5d %7.4f %7.4f \n", thisIndex.x, thisIndex.y, i, particles[i].x, particles[i].y);
   CkPrintf("*****************************************************\n");
 #endif

--- a/examples/charm++/Molecular2D/Patch.C
+++ b/examples/charm++/Molecular2D/Patch.C
@@ -177,7 +177,7 @@ void Patch::start() {
 }
 
 // Function to update forces coming from a compute
-void Patch::updateForces(std::vector<Particle> updates) {
+void Patch::updateForces(const std::vector<Particle> &updates) {
   int i, x, y, x1, y1;
   std::vector<Particle> outgoing[NUM_NEIGHBORS];
 
@@ -270,7 +270,7 @@ void Patch::checkNextStep(){
 
 // Function that receives a set of particles and updates the 
 // forces of them into the local set
-void Patch::updateParticles(std::vector<Particle> updates) {
+void Patch::updateParticles(const std::vector<Particle> &updates) {
   updateCount++;
 
   for( int i=0; i < updates.size(); i++) {

--- a/examples/charm++/Molecular2D/Patch.C
+++ b/examples/charm++/Molecular2D/Patch.C
@@ -177,7 +177,7 @@ void Patch::start() {
 }
 
 // Function to update forces coming from a compute
-void Patch::updateForces(CkVec<Particle> &updates) {
+void Patch::updateForces(CkVec<Particle> updates) {
   int i, x, y, x1, y1;
   CkVec<Particle> outgoing[NUM_NEIGHBORS];
 
@@ -270,7 +270,7 @@ void Patch::checkNextStep(){
 
 // Function that receives a set of particles and updates the 
 // forces of them into the local set
-void Patch::updateParticles(CkVec<Particle> &updates) {
+void Patch::updateParticles(CkVec<Particle> updates) {
   updateCount++;
 
   for( int i=0; i < updates.length(); i++) {

--- a/examples/charm++/Molecular2D/Patch.ci
+++ b/examples/charm++/Molecular2D/Patch.ci
@@ -22,14 +22,14 @@ mainmodule Patch {
     entry Patch();
     entry void start();
     entry void createComputes();
-    entry void updateForces(CkVec<Particle> particles);
-    entry void updateParticles(CkVec<Particle> updates);
+    entry void updateForces(std::vector<Particle> particles);
+    entry void updateParticles(std::vector<Particle> updates);
     // entry void requestNextFrame(liveVizRequestMsg *m);
   };
 
   array [4D] Compute {
     entry Compute();
-    entry void interact(CkVec<Particle>, int i, int j);
+    entry void interact(std::vector<Particle>, int i, int j);
   };
 
 };

--- a/examples/charm++/Molecular2D/Patch.ci
+++ b/examples/charm++/Molecular2D/Patch.ci
@@ -22,8 +22,8 @@ mainmodule Patch {
     entry Patch();
     entry void start();
     entry void createComputes();
-    entry void updateForces(std::vector<Particle> particles);
-    entry void updateParticles(std::vector<Particle> updates);
+    entry void updateForces(const std::vector<Particle> &particles);
+    entry void updateParticles(const std::vector<Particle> &updates);
     // entry void requestNextFrame(liveVizRequestMsg *m);
   };
 

--- a/examples/charm++/Molecular2D/Patch.h
+++ b/examples/charm++/Molecular2D/Patch.h
@@ -47,8 +47,8 @@ class Patch : public CBase_Patch {
 
     void start();
     void createComputes();
-    void updateParticles(CkVec<Particle> &);
-    void updateForces(CkVec<Particle> &);
+    void updateParticles(CkVec<Particle>);
+    void updateForces(CkVec<Particle>);
     void limitVelocity(Particle &p);
     Particle& wrapAround(Particle &p);
 #ifdef RUN_LIVEVIZ

--- a/examples/charm++/Molecular2D/Patch.h
+++ b/examples/charm++/Molecular2D/Patch.h
@@ -8,6 +8,8 @@
 #ifndef __PATCH_H__
 #define __PATCH_H__
 
+#include <pup_stl.h>
+
 /** \class Main
  *
  */
@@ -47,8 +49,8 @@ class Patch : public CBase_Patch {
 
     void start();
     void createComputes();
-    void updateParticles(std::vector<Particle>);
-    void updateForces(std::vector<Particle>);
+    void updateParticles(const std::vector<Particle> &);
+    void updateForces(const std::vector<Particle> &);
     void limitVelocity(Particle &p);
     Particle& wrapAround(Particle &p);
 #ifdef RUN_LIVEVIZ

--- a/examples/charm++/Molecular2D/Patch.h
+++ b/examples/charm++/Molecular2D/Patch.h
@@ -26,8 +26,8 @@ class Main : public CBase_Main {
  */
 class Patch : public CBase_Patch {
   private:
-    CkVec<Particle> particles;
-    CkVec<Particle> incomingParticles;
+    std::vector<Particle> particles;
+    std::vector<Particle> incomingParticles;
     int forceCount;		// to count the returns from interactions
     int stepCount;		// to count the number of steps, and decide when to stop
     int updateCount;
@@ -47,8 +47,8 @@ class Patch : public CBase_Patch {
 
     void start();
     void createComputes();
-    void updateParticles(CkVec<Particle>);
-    void updateForces(CkVec<Particle>);
+    void updateParticles(std::vector<Particle>);
+    void updateForces(std::vector<Particle>);
     void limitVelocity(Particle &p);
     Particle& wrapAround(Particle &p);
 #ifdef RUN_LIVEVIZ

--- a/examples/charm++/Molecular2D/common.h
+++ b/examples/charm++/Molecular2D/common.h
@@ -7,7 +7,7 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
-#include "pup.h"
+#include "pup_stl.h"
 
 #define DEFAULT_MASS		1
 #define DEFAULT_DELTA		0.005

--- a/examples/charm++/Molecular2D/common.h
+++ b/examples/charm++/Molecular2D/common.h
@@ -86,7 +86,7 @@ class Color {
       } else if(index % total == 3) {
 	R = 100;
 	G = 255;
-	255;
+	B = 255;
       } else if(index % total == 4) {
 	R = 100;
 	G = 255;


### PR DESCRIPTION
Uses std::vector in place of CkVec in the Molecular2D example, fixes the bug (#3834) in the compilation of Molecular2D by using const references in the method parameters of updateParticles and updateForces, and updates the documentation to clarify how pup_stl.h should be used.