### PR TITLE
Fixing cmake charm++ and charm4py build with cuda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,8 +209,7 @@ endif()
 option(BUILD_SHARED        "Build Charm++ dynamic libraries" OFF)
 
 # Other options
-option(CUDA                "Build with CUDA support" OFF)
-
+option(BUILD_CUDA          "Build with CUDA support" OFF)
 option(PXSHM               "Build with PXSHM" OFF)
 
 # LRTS PMI options
@@ -224,8 +223,6 @@ string(REPLACE ";" " " MY_EXTRA_OPTS "${MY_EXTRA_OPTS}")
 set(OPTS "${OPTS} ${MY_EXTRA_OPTS}")
 set(OPTSATBUILDTIME "${OPTSATBUILDTIME} ${MY_EXTRA_OPTS}")
 
-# We need both BUILD_CUDA and CUDA
-set(BUILD_CUDA ${CUDA})
 
 # Also build shared Charm++ libraries in lib_so/
 if(BUILD_SHARED)
@@ -689,7 +686,8 @@ configure_file(src/scripts/conv-config.sh                    include/ COPYONLY)
 configure_file(src/arch/${VDIR}/conv-mach.sh                 include/ COPYONLY)
 
 set(CUDA_DIR "")
-if(CUDA)
+if(BUILD_CUDA)
+  
   file(GLOB_RECURSE hybridAPI-h-sources ${CMAKE_SOURCE_DIR}/src/arch/cuda/*.h)
   file(GLOB_RECURSE hybridAPI-cxx-sources ${CMAKE_SOURCE_DIR}/src/arch/cuda/*.cpp)
   foreach(file ${hybridAPI-h-sources})
@@ -1096,6 +1094,7 @@ foreach(l CUDA_DIR BUILD_CUDA CMK_AMPI_WITH_ROMIO CMK_MACOSX CMK_BUILD_PYTHON
 endforeach(l)
 
 # Add options
+set(CUDA ${BUILD_CUDA}) # need CUDA to match conv-mach file name
 foreach(opt SMP OMP TCP PTHREADS SYNCFT PXSHM PERSISTENT OOC CUDA PAPI CXI)
     if(${opt})
         string(TOLOWER ${opt} optl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -993,6 +993,10 @@ if(${TARGET} STREQUAL "charm4py")
     target_link_libraries(charm ck converse memory-default threads-default ldb-rand "-Llib/ -standalone -whole-archive -c++stl -shared")
   endif()
 
+  if (${BUILD_CUDA})
+    target_link_libraries(charm cudart cudahybridapi)
+  endif()
+
   add_dependencies(charm hwloc)
 endif()
 

--- a/buildcmake
+++ b/buildcmake
@@ -647,7 +647,7 @@ CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake "$my_srcdir" \
   -DCCS="$opt_ccs" \
   -DCHARMDEBUG="$opt_charmdebug" \
   -DCONTROLPOINT="$opt_controlpoint" \
-  -DCUDA="$opt_cuda" \
+  -DBUILD_CUDA="$opt_cuda" \
   -DDISABLE_TLS="$opt_disabletls" \
   -DDRONE_MODE="$opt_drone_mode" \
   -DENABLE_FORTRAN=$opt_enable_fortran \


### PR DESCRIPTION
Previously, attempting to build with the cuda option using the cmake build resulted in the following error (on Delta):

```
> -- Found CUDAToolkit: /sw/spack/deltas11-2023-03/apps/linux-rhel8-zen3/gcc-11.4.0/cuda-11.8.0-vfixfmc/include (found version "11.8.89") 
> -- The CUDA compiler identification is GNU 11.4.0
> -- Detecting CUDA compiler ABI info
> -- Detecting CUDA compiler ABI info - failed
> -- Check for working CUDA compiler: /sw/spack/deltas11-2023-03/apps/linux-rhel8-zen3/gcc-11.4.0/cuda-11.8.0-vfixfmc/bin/nvcc
> -- Check for working CUDA compiler: /sw/spack/deltas11-2023-03/apps/linux-rhel8-zen3/gcc-11.4.0/cuda-11.8.0-vfixfmc/bin/nvcc - broken
> CMake Error at /usr/share/cmake/Modules/CMakeTestCUDACompiler.cmake:52 (message):
>   The CUDA compiler
> 
>     "/sw/spack/deltas11-2023-03/apps/linux-rhel8-zen3/gcc-11.4.0/cuda-11.8.0-vfixfmc/bin/nvcc"
> 
>   is not able to compile a simple test program.
> 
>   It fails with the following output:
> 
>     Change Dir: /u/mtaylor2/software/charm/mpi-linux-x86_64-cuda/CMakeFiles/CMakeTmp
>     
>     Run Build Command(s):/usr/bin/gmake -f Makefile cmTC_4c559/fast && /usr/bin/gmake  -f CMakeFiles/cmTC_4c559.dir/build.make CMakeFiles/cmTC_4c559.dir/build
>     gmake[1]: Entering directory '/u/mtaylor2/software/charm/mpi-linux-x86_64-cuda/CMakeFiles/CMakeTmp'
>     Building CUDA object CMakeFiles/cmTC_4c559.dir/main.cu.o
>     /sw/spack/deltas11-2023-03/apps/linux-rhel8-zen3/gcc-11.4.0/cuda-11.8.0-vfixfmc/bin/nvcc      -c /u/mtaylor2/software/charm/mpi-linux-x86_64-cuda/CMakeFiles/CMakeTmp/main.cu -o CMakeFiles/cmTC_4c559.dir/main.cu.o
>     Linking CUDA executable cmTC_4c559
>     /usr/bin/cmake -E cmake_link_script CMakeFiles/cmTC_4c559.dir/link.txt --verbose=1
>     "" CMakeFiles/cmTC_4c559.dir/main.cu.o -o cmTC_4c559 
>     Error running link command: No such file or directory
>     gmake[1]: *** [CMakeFiles/cmTC_4c559.dir/build.make:99: cmTC_4c559] Error 2
>     gmake[1]: Leaving directory '/u/mtaylor2/software/charm/mpi-linux-x86_64-cuda/CMakeFiles/CMakeTmp'
>     gmake: *** [Makefile:127: cmTC_4c559/fast] Error 2
```

The issue: the cuda library is referenced via the variable `CUDA`, and the cmake script introduces an option also named `CUDA`. This introduces confusion when cmake tries to find cuda: `enable_language(CUDA)`.

This PR fixes the issue by renaming the `CUDA` option as `BUILD_CUDA`. The existing cmake structure requires that there still exists an option named `CUDA` for the `conv-mach-cuda.h` discovery, so I pushed the creation of the `CUDA` option to after all cuda library setup.

This PR also links in the necessary cuda and HAPI libraries to charmlib.so, for use in charm4py.