### PR TITLE
Mark comparison operators in ck-core const

### DIFF
--- a/src/ck-core/charm++.h
+++ b/src/ck-core/charm++.h
@@ -875,7 +875,7 @@ class CProxy_Group : public CProxy {
 /*    CProxy_Group(const NodeGroup *g)  //<- for compatability with NodeGroups
         :CProxy(), _ck_gid(g->ckGetGroupID()) {}*/
 
-    bool operator==(const CProxy_Group& other) {
+    bool operator==(const CProxy_Group& other) const {
       return ckGetGroupID() == other.ckGetGroupID();
     }
 
@@ -918,7 +918,7 @@ class CProxyElement_Group : public CProxy_Group {
     /*CProxyElement_Group(const NodeGroup *g)  //<- for compatability with NodeGroups
         :CProxy_Group(g), _onPE(CkMyPe()) {}*/
 
-    bool operator==(const CProxyElement_Group& other) {
+    bool operator==(const CProxyElement_Group& other) const {
       return ckGetGroupID() == other.ckGetGroupID() &&
              ckGetGroupPe() == other.ckGetGroupPe();
     }
@@ -1024,7 +1024,7 @@ class CProxy_NodeGroup : public CProxy{
 /*    CProxy_Group(const NodeGroup *g)  //<- for compatability with NodeGroups
         :CProxy(), _ck_gid(g->ckGetGroupID()) {}*/
 
-    bool operator==(const CProxy_NodeGroup& other) {
+    bool operator==(const CProxy_NodeGroup& other) const {
       return ckGetGroupID() == other.ckGetGroupID();
     }
 

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -114,7 +114,7 @@ public:
   CProxy_ArrayBase(const ArrayElement* e);
   CProxy_ArrayBase(const CProxy_ArrayBase& cs) : CProxy(cs), _aid(cs.ckGetArrayID()) {}
 
-  bool operator==(const CProxy_ArrayBase& other)
+  bool operator==(const CProxy_ArrayBase& other) const
   {
     return ckGetArrayID() == other.ckGetArrayID();
   }
@@ -176,7 +176,7 @@ public:
     return *this;
   }
 
-  bool operator==(const CProxyElement_ArrayBase& other)
+  bool operator==(const CProxyElement_ArrayBase& other) const
   {
     return ckGetArrayID() == other.ckGetArrayID() && ckGetIndex() == other.ckGetIndex();
   }

--- a/src/ck-core/ckarrayindex.h
+++ b/src/ck-core/ckarrayindex.h
@@ -58,7 +58,7 @@ struct CkArrayIndexBase
             p((char *)this, sizeof(CkArrayIndexBase));
         }
 
-        bool operator==(CkArrayIndexBase &other) {
+        bool operator==(const CkArrayIndexBase &other) const {
           if(nInts != other.nInts) return false;
           if(dimension != other.dimension) return false;
           for (int i=0;i<nInts;i++) {

--- a/src/ck-core/ckcallback.h
+++ b/src/ck-core/ckcallback.h
@@ -156,7 +156,7 @@ public:
 	bool isExtCallback = false;
 #endif
 
-	bool operator==(CkCallback & other){
+	bool operator==(const CkCallback & other) const {
 	  if(type != other.type)
 	    return false;
 	  switch (type) {

--- a/src/ck-core/cksection.h
+++ b/src/ck-core/cksection.h
@@ -43,7 +43,7 @@ public:
   CkSectionInfo(int e, void *p, int r, CkArrayID _aid)
     : val(p), aid(_aid), pe(e), redNo(r) { }
 
-  bool operator==(CkSectionInfo &other) const {
+  bool operator==(const CkSectionInfo &other) const {
     return (val == other.val && aid == other.aid && pe == other.pe && redNo == other.redNo);
   }
 


### PR DESCRIPTION
There are a few other suspicious ones elsewhere in the repo, like `src/ck-cp/controlPoints.h`, but I couldn't quickly figure out how to compile those files so I don't want to change them and break something.