### PR TITLE
bugfix: remove redundant shift after exit

### DIFF
--- a/src/arch/multicore/charmrun
+++ b/src/arch/multicore/charmrun
@@ -40,7 +40,6 @@ do
 	+n[0-9]*)
 		printf "Charmrun> Error: Multicore builds only support single-node runs.\n"
 		exit 1
-		shift
 		;;
 	++quiet)
 		QUIET=1


### PR DESCRIPTION
shellcheck is failing due to vestigial code after exit 