### PR TITLE
bugfix: due to bugs in the ubuntu-latest mpich install, use 22.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
 
   mpi-linux-x86_64:
     timeout-minutes: 90
-    runs-on: ubuntu-24.04  #  ubuntu-latest does not work
+    runs-on: ubuntu-22.04  #  ubuntu-latest does not work
     steps:
     - uses: actions/checkout@v4
     - name: install-prerequisites
@@ -117,7 +117,7 @@ jobs:
 
   mpi-linux-x86_64_syncft:
     timeout-minutes: 90
-    runs-on: ubuntu-24.04  #  ubuntu-latest does not work
+    runs-on: ubuntu-22.04  #  ubuntu-latest does not work
     steps:
     - uses: actions/checkout@v4
     - name: install-prerequisites
@@ -377,7 +377,7 @@ jobs:
 
   ucx-linux-x86_64_openpmix:
     timeout-minutes: 60
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
     # Uncomment the lines below to set up a tmate session for debugging.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
 
   mpi-linux-x86_64:
     timeout-minutes: 90
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04  #  ubuntu-latest does not work
     steps:
     - uses: actions/checkout@v4
     - name: install-prerequisites
@@ -117,7 +117,7 @@ jobs:
 
   mpi-linux-x86_64_syncft:
     timeout-minutes: 90
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04  #  ubuntu-latest does not work
     steps:
     - uses: actions/checkout@v4
     - name: install-prerequisites

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
 
   mpi-linux-x86_64:
     timeout-minutes: 90
-    runs-on: ubuntu-20.04  #  ubuntu-latest does not work
+    runs-on: ubuntu-24.04  #  ubuntu-latest does not work
     steps:
     - uses: actions/checkout@v4
     - name: install-prerequisites
@@ -117,7 +117,7 @@ jobs:
 
   mpi-linux-x86_64_syncft:
     timeout-minutes: 90
-    runs-on: ubuntu-20.04  #  ubuntu-latest does not work
+    runs-on: ubuntu-24.04  #  ubuntu-latest does not work
     steps:
     - uses: actions/checkout@v4
     - name: install-prerequisites
@@ -377,7 +377,7 @@ jobs:
 
   ucx-linux-x86_64_openpmix:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v1
     # Uncomment the lines below to set up a tmate session for debugging.


### PR DESCRIPTION
Work around the fact that the MPICH install in ubuntu-latest has some wacky misconfiguration that makes it launch an application like a bunch of independent processes all at rank 0.