### PR TITLE
update AMPI and ROMIO to be compatible gcc14 for spack

### DIFF
--- a/src/libs/ck-libs/ampi/romio/configure
+++ b/src/libs/ck-libs/ampi/romio/configure
@@ -23719,7 +23719,7 @@ $as_echo_n "checking if a simple MPI program compiles and links... " >&6; }
   rm -f mpitest.c
   cat > mpitest.c <<EOF
 #include "mpi.h"
-     main(int argc, char **argv)
+     int main(int argc, char **argv)
      {
          MPI_Init(&argc,&argv);
          MPI_Finalize();

--- a/src/libs/ck-libs/ampi/romio/include/mpio_functions.h
+++ b/src/libs/ck-libs/ampi/romio/include/mpio_functions.h
@@ -184,7 +184,7 @@ AMPI_CUSTOM_FUNC(int, MPI_Type_create_subarray, int ndims, const int array_of_si
 /* Section 4.14.5 */
 AMPI_CUSTOM_FUNC(int, MPI_Type_create_darray, int size, int rank, int ndims, const int array_of_gsizes[],
                            const int array_of_distribs[], const int array_of_dargs[],
-                           const int array_of_psizes, int order, MPI_Datatype oldtype,
+                           const int array_of_psizes[], int order, MPI_Datatype oldtype,
                            MPI_Datatype *newtype)
 #endif
 


### PR DESCRIPTION
Fix a gcc 14 "bug" in the ROMIO configure test by explicit return type of int for main function.

Reconcile incompatible function prototypes to the one in the MPI standard.