### PR TITLE
bugfix: avert ci failures by disabling ROMIO by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,8 +597,9 @@ if(NOT CMK_AMPI_ONLY)
 endif()
 
 #disable ROMIO due to GCC 14 cascade of failures
-set(CMK_AMPI_WITH_ROMIO 0)
-
+if(NOT DEFINED CMK_AMPI_WITH_ROMIO)
+  set(CMK_AMPI_WITH_ROMIO 0)
+endif()  
 set(CMK_ENABLE_C11   ${CMAKE_C11_EXTENSION_COMPILE_OPTION})
 
 # Use -std=gnu++11 if available

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,9 +596,8 @@ if(NOT CMK_AMPI_ONLY)
   set(CMK_AMPI_ONLY 0)
 endif()
 
-if(NOT DEFINED CMK_AMPI_WITH_ROMIO)
-  set(CMK_AMPI_WITH_ROMIO 1)
-endif()
+#disable ROMIO due to GCC 14 cascade of failures
+set(CMK_AMPI_WITH_ROMIO 0)
 
 set(CMK_ENABLE_C11   ${CMAKE_C11_EXTENSION_COMPILE_OPTION})
 

--- a/README.ampi
+++ b/README.ampi
@@ -92,5 +92,10 @@ prefixed with AMPI_:
     * AMPI_Get_command_argument returns an argument from the command line
       to a Fortran AMPI program.
 
+MPI-IO is support is available via our port of the ROMIO library. however:
+    * ROMIO is not built by default due to the fact that the current port is
+      incompatible with GCC 14 and beyond.  Add --with-romio to your
+      build line to enable MPI-IO support via ROMIO.
+
 Note that AMPI defines a preprocessor symbol "AMPI" so that user codes can
 check for AMPI's presence at compile time using "#ifdef AMPI".

--- a/buildcmake
+++ b/buildcmake
@@ -144,13 +144,13 @@ opt_tracing= #undef
 opt_tracing_commthread=0
 opt_zlib=1
 
-# default to building ROMIO on AMPI where supported
+# default to not building ROMIO on AMPI due to GCC 14 cascade failures
 case "$actual_triplet" in
   *-win-*)
     opt_romio=0
     ;;
   *)
-    opt_romio=1
+    opt_romio=0
     ;;
 esac
 

--- a/buildold
+++ b/buildold
@@ -270,13 +270,13 @@ shift
 
 OPT_DIRS=("$src/$BASEVERSION" "$src/$ARCH" "$src/common")
 
-# default to building ROMIO on AMPI where supported
+# default to not building ROMIO due to GCC 14 cascade failures
 case "$BASEVERSION" in
   *-win-*)
     WITH_ROMIO=''
     ;;
   *)
-    WITH_ROMIO='true'
+    WITH_ROMIO=''
     ;;
 esac
 

--- a/doc/ampi/01-introduction.rst
+++ b/doc/ampi/01-introduction.rst
@@ -204,8 +204,12 @@ MPI Standards Compliance
 
 Currently AMPI supports the MPI-2.2 standard, with preliminary support
 for most MPI-3.1 features and a collection of extensions explained in
-detail in this manual. One-sided communication calls in MPI-2 and MPI-3
-are implemented, but they do not yet take advantage of RMA features.
-Non-blocking collectives have been defined in AMPI since before
-MPI-3.0’s adoption of them. ROMIO (http://www-unix.mcs.anl.gov/romio/) has been integrated into
-AMPI to support parallel I/O features.
+detail in this manual. One-sided communication calls in MPI-2 and
+MPI-3 are implemented, but they do not yet take advantage of RMA
+features.  Non-blocking collectives have been defined in AMPI since
+before MPI-3.0’s adoption of them. ROMIO
+(http://www-unix.mcs.anl.gov/romio/) has been integrated into AMPI to
+support parallel I/O features.  However, ROMIO is not enabled by
+default due to incompatibility with the strict requirements of GCC 14
+(and above).  Add --with-romio to the build line and use a more
+permissive compiler than GCC 14 to enable the ROMIO based I/O features.

--- a/src/libs/ck-libs/ampi/CMakeLists.txt
+++ b/src/libs/ck-libs/ampi/CMakeLists.txt
@@ -2,7 +2,9 @@ set(ampi-cxx-sources ampi.C ampiMisc.C ampiOneSided.C ampif.C ddt.C mpich-alltoa
 
 set(ampi-f90-sources ampimod.f90)
 #disable ROMIO due to GCC 14 cascade of failures
-set(CMK_AMPI_WITH_ROMIO 0)
+if(NOT DEFINED CMK_AMPI_WITH_ROMIO)
+       set(CMK_AMPI_WITH_ROMIO 0)
+endif()       
 
 
 set(ampi-h-sources ampi.h ampi-interoperate.h ampiimpl.h ddt.h ampi_functions.h ampi_funcptr.h ampi_funcptr_loader.h

--- a/src/libs/ck-libs/ampi/CMakeLists.txt
+++ b/src/libs/ck-libs/ampi/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(ampi-cxx-sources ampi.C ampiMisc.C ampiOneSided.C ampif.C ddt.C mpich-alltoall.C ampi_mpix.C ampi_noimpl.C)
 
 set(ampi-f90-sources ampimod.f90)
+#disable ROMIO due to GCC 14 cascade of failures
+set(CMK_AMPI_WITH_ROMIO 0)
+
 
 set(ampi-h-sources ampi.h ampi-interoperate.h ampiimpl.h ddt.h ampi_functions.h ampi_funcptr.h ampi_funcptr_loader.h
                    romio-stub/mpio_globals.h)
@@ -180,6 +183,7 @@ endif()
 
 # ROMIO
 set(romio-objects)
+
 if(CMK_AMPI_WITH_ROMIO)
     set(romio_dir ${CMAKE_BINARY_DIR}/src/libs/ck-libs/ampi/romio-prefix/src/romio)
 


### PR DESCRIPTION
GCC 14's strict adherence to types is not compatible with our ROMIO implementation's use (AKA abuse) of the old tolerance for casting everything to int.

ROMIO is only necessary for AMPI applications relying on MPI IO, which appears to be the null set at this time.

This PR disables ROMIO by default in both build and buildold.  

A better solution would be a re-implementation of ROMIO, but given the lack of user demand, that is not a current priority.