### PR TITLE
Fix --enable-shrinkexpand build 

### DIFF
--- a/src/ck-ldb/CentralLB.C
+++ b/src/ck-ldb/CentralLB.C
@@ -1070,8 +1070,9 @@ void CentralLB::CheckForRealloc(){
 
 void CentralLB::ResumeFromReallocCheckpoint(){
 #if CMK_SHRINK_EXPAND
-    std::vector<char> avail(se_avail_vector.begin(), se_avail_vector.begin() + CkNumPes());
-    se_avail_vector.clear();
+    const int count = CkNumPes();
+    std::vector<char> avail(se_avail_vector, se_avail_vector + count);
+    memset(se_avail_vector, 0, sizeof(char) * count);
     thisProxy.WillIbekilled(avail, numProcessAfterRestart);
 #endif
 }


### PR DESCRIPTION
Hello,

I want to compile Charm++ with the shrink-expand feature as suggested in the [guide](https://charm.readthedocs.io/en/latest/charm++/manual.html#malleability-shrink-expand-number-of-processors):

```
./build charm++ netlrts-linux-x86_64 --enable-shrinkexpand
```

I encountered the following compilation error:

```
...
/home/tan/master/thesis/opt/charm/src/ck-ldb/CentralLB.C: In member function ‘void CentralLB::ResumeFromReallocCheckpoint()’:
/home/tan/master/thesis/opt/charm/src/ck-ldb/CentralLB.C:1073:45: error: request for member ‘begin’ in ‘se_avail_vector’, which is of non-class type ‘char*’
 1073 |     std::vector<char> avail(se_avail_vector.begin(), se_avail_vector.begin() + CkNumPes());
      |                                             ^~~~~
/home/tan/master/thesis/opt/charm/src/ck-ldb/CentralLB.C:1073:70: error: request for member ‘begin’ in ‘se_avail_vector’, which is of non-class type ‘char*’
 1073 |     std::vector<char> avail(se_avail_vector.begin(), se_avail_vector.begin() + CkNumPes());
      |                                                                      ^~~~~
/home/tan/master/thesis/opt/charm/src/ck-ldb/CentralLB.C:1074:21: error: request for member ‘clear’ in ‘se_avail_vector’, which is of non-class type ‘char*’
 1074 |     se_avail_vector.clear();
      |                     ^~~~~
...
```
Since se_avail_vector is a `char*` and allocated here:
```
src/ck-ldb/manager.C:35:    se_avail_vector = (char *)malloc(sizeof(char) * CkNumPes());
```
Fixed by using ptr arithmetic and memset instead of calling clear.