### PR TITLE
bugfix: update NAMD deploy token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,7 +193,7 @@ jobs:
       if: ${{ env.namd_secret != '' }}
       run: |
         cd ..
-        git clone https://${{ secrets.NAMD_CI_USERNAME_TOKEN }}@gitlab.com/tcbgUIUC/namd.git
+        git clone https://${{ secrets.NAMD_CI_USERNAME_TOKEN }}:${{ secrets.NAMD_CI_DEPLOY_PASSWORD }}@gitlab.com/tcbgUIUC/namd.git
         cd namd
         ./config Linux-x86_64-g++ --charm-base ../charm --charm-arch netlrts-linux-x86_64 --without-tcl
         cd Linux-x86_64-g++


### PR DESCRIPTION
The old deploy token expired.
This one uses two repo secrets, one for the username, another for the password token
