### PR TITLE
cmake min to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,19 +334,10 @@ set(CMK_HAS_PYTHON 0)
 set(CMK_PYTHON_VERSION "")
 set(CMK_BUILD_PYTHON "")
 
-if(CMAKE_VERSION VERSION_GREATER 3.12 OR CMAKE_VERSION VERSION_EQUAL 3.12)
-  find_package(Python2 COMPONENTS Interpreter)
-  if(Python2_FOUND)
-    set(CMK_PYTHON_VERSION_MAJOR ${Python2_VERSION_MAJOR})
-    set(CMK_PYTHON_VERSION_MINOR ${Python2_VERSION_MINOR})
-  endif()
-else()
-  set(Python_ADDITIONAL_VERSIONS 2)
-  find_package(PythonInterp)
-  if(PYTHONINTERP_FOUND)
-    set(CMK_PYTHON_VERSION_MAJOR ${PYTHON_VERSION_MAJOR})
-    set(CMK_PYTHON_VERSION_MINOR ${PYTHON_VERSION_MINOR})
-  endif()
+find_package(Python2 COMPONENTS Interpreter)
+if(Python2_FOUND)
+  set(CMK_PYTHON_VERSION_MAJOR ${Python2_VERSION_MAJOR})
+  set(CMK_PYTHON_VERSION_MINOR ${Python2_VERSION_MINOR})
 endif()
 
 if(CMK_PYTHON_VERSION_MAJOR)
@@ -597,7 +588,7 @@ endif()
 #disable ROMIO due to GCC 14 cascade of failures
 if(NOT DEFINED CMK_AMPI_WITH_ROMIO)
   set(CMK_AMPI_WITH_ROMIO 0)
-endif()  
+endif()
 set(CMK_ENABLE_C11   ${CMAKE_C11_EXTENSION_COMPILE_OPTION})
 
 # Use -std=gnu++11 if available
@@ -685,7 +676,7 @@ configure_file(src/arch/${VDIR}/conv-mach.sh                 include/ COPYONLY)
 
 set(CUDA_DIR "")
 if(BUILD_CUDA)
-  
+
   file(GLOB_RECURSE hybridAPI-h-sources ${CMAKE_SOURCE_DIR}/src/arch/cuda/*.h)
   file(GLOB_RECURSE hybridAPI-cxx-sources ${CMAKE_SOURCE_DIR}/src/arch/cuda/*.cpp)
   foreach(file ${hybridAPI-h-sources})
@@ -1239,13 +1230,9 @@ configure_package_config_file(
   "${CMAKE_BINARY_DIR}/lib/cmake/Charm/CharmConfig.cmake"
   INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/Charm/CharmConfig.cmake
   )
-# We want the `SameMinorVersion` compatibility mode, but it isn't available
-# before CMake v3.11
-if(CMAKE_VERSION VERSION_GREATER 3.11 OR CMAKE_VERSION VERSION_EQUAL 3.11)
-  set(VERSION_COMPATIBILITY_MODE SameMinorVersion)
-else()
-  set(VERSION_COMPATIBILITY_MODE ExactVersion)
-endif()
+
+set(VERSION_COMPATIBILITY_MODE SameMinorVersion)
+
 write_basic_package_version_file(
   ${CMAKE_BINARY_DIR}/lib/cmake/Charm/CharmConfigVersion.cmake
   COMPATIBILITY ${VERSION_COMPATIBILITY_MODE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # - the buildcmake script
 # - files in cmake/
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 
 # Print warning
 message("##################################################################")
@@ -21,12 +21,10 @@ message("# with the below configuration information.                      #")
 message("# You can run './buildold' to use the previous build system.     #")
 message("##################################################################")
 
-if(CMAKE_VERSION VERSION_GREATER 3.12 OR CMAKE_VERSION VERSION_EQUAL 3.12)
-  cmake_policy(SET CMP0075 NEW)
+cmake_policy(SET CMP0075 NEW)
 
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-    cmake_policy(SET CMP0102 NEW)
-  endif()
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+  cmake_policy(SET CMP0102 NEW)
 endif()
 
 # Fortran is optional, so don't include it in LANGUAGES here

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # - the buildcmake script
 # - files in cmake/
 
-cmake_minimum_required(VERSION 3.4...3.5)
+cmake_minimum_required(VERSION 3.10)
 
 # Print warning
 message("##################################################################")


### PR DESCRIPTION
CMake 4.0 now throws an error if the minimum specified version is below 3.5, so this updates the version.