### PR TITLE
CCS communication support for charm4py

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
   cuda_netlrts-linux-x86_64_buildonly:
     # Buildonly test, as CUDA needs an actual device to run.
     timeout-minutes: 45
-    runs-on: ubuntu-20.04  # FIXME: ubuntu-latest does not work
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: build

--- a/src/conv-ccs/conv-ccs.C
+++ b/src/conv-ccs/conv-ccs.C
@@ -37,6 +37,29 @@ static void initHandlerRec(CcsHandlerRec *c,const char *name) {
   c->nCalls=0;
 }
 
+#if CMK_CHARM4PY
+static void callHandlerRec(CcsHandlerRec *c, int reqLen, const void *reqData)
+{
+  c->nCalls++;
+  //structure of message: reserved header + handler name length (up to 32) + data length (up to 1024)
+  //+handler name + data
+  //get handler name and length (up to 32)
+  const char *handlerStr = c->name;
+  const int handlerStrLen = strlen(handlerStr);
+  //reserved header name and data
+  char *cmsg = (char *) CmiAlloc(CmiReservedHeaderSize+2*sizeof(int)+CCS_MAXHANDLER+reqLen);
+  //handler length (up to 32)
+  memcpy(cmsg+CmiReservedHeaderSize, &handlerStrLen, sizeof(int));
+  //data length (up to 1024)
+  memcpy(cmsg+CmiReservedHeaderSize+sizeof(int), &reqLen, sizeof(int));
+  //handler name (up to 32)
+  memcpy(cmsg+CmiReservedHeaderSize+2*sizeof(int), handlerStr, handlerStrLen);
+  //data
+  memcpy(cmsg+CmiReservedHeaderSize+2*sizeof(int)+CCS_MAXHANDLER, reqData, reqLen);
+  (c->fnOld)(cmsg);
+}
+
+#else
 static void callHandlerRec(CcsHandlerRec *c,int reqLen,const void *reqData) {
 	c->nCalls++;
 	if (c->fnOld) 
@@ -52,6 +75,8 @@ static void callHandlerRec(CcsHandlerRec *c,int reqLen,const void *reqData) {
 		(c->fn)(c->userPtr, reqLen, reqData);
 	}
 }
+
+#endif
 
 /*Table maps handler name to CcsHandler object*/
 CpvDeclare(CcsHandlerTable, ccsTab);

--- a/src/conv-ccs/conv-ccs.C
+++ b/src/conv-ccs/conv-ccs.C
@@ -64,6 +64,14 @@ void CcsRegisterHandler(const char *name, CmiHandler fn) {
   cp.fnOld=fn;
   *(CcsHandlerRec *)CkHashtablePut(CpvAccess(ccsTab),(void *)&cp.name)=cp;
 }
+
+#ifdef CMK_CHARM4PY
+void CcsRegisterHandlerExt(const char *ccs_handlername, void *fn)
+{
+  CcsRegisterHandler(ccs_handlername, (CmiHandler)fn);
+}
+#endif
+
 void CcsRegisterHandlerFn(const char *name, CcsHandlerFn fn, void *ptr) {
   CcsHandlerRec cp;
   initHandlerRec(&cp,name);

--- a/src/conv-ccs/conv-ccs.h
+++ b/src/conv-ccs/conv-ccs.h
@@ -51,6 +51,10 @@ typedef struct CcsHandlerRec {
  */
 void CcsRegisterHandler(const char *ccs_handlername, CmiHandler fn);
 
+#ifdef CMK_CHARM4PY
+void CcsRegisterHandlerExt(const char *ccs_handlername, void *fn);
+#endif
+
 CcsHandlerRec *CcsGetHandler(const char *name);
 
 /**

--- a/src/conv-core/conv-header.h
+++ b/src/conv-core/conv-header.h
@@ -42,6 +42,9 @@ typedef struct CMK_MSG_HEADER_EXT   CmiMsgHeaderExt;
 
 #ifndef CmiReservedHeaderSize
 #  define CmiReservedHeaderSize   CmiExtHeaderSizeBytes
+
+int getCmiReservedHeaderSize(void);
+
 #endif
 
 #endif

--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -4382,4 +4382,9 @@ void CmiSetPeHelpsOtherThreads(int input) {
   CmiMemoryWriteFence();
 }
 
+int getCmiReservedHeaderSize()
+{
+  return CmiReservedHeaderSize;
+}
+
 /*@}*/


### PR DESCRIPTION
This exposes CCS methods to Cython to allow Charm4Py programs to be used as CCS servers.