### PR TITLE
Fix Charm4py HAPI

### DIFF
--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -511,7 +511,7 @@ extern void CkEnableTracing(int epIdx);
 extern void CkCallWhenIdle(int epIdx, void* obj);
 
 
-#if CMK_CHARM4PY && CMK_CUDA
+#if CMK_CHARM4PY
 extern void CkHapiAddCallback(long stream, void (*cb)(void*, void*), int fid);
 #endif
 

--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -2638,18 +2638,25 @@ void CkArrayExtSend_multi(int aid, int *idx, int ndims, int epIdx, int num_bufs,
 }
 
 
+// HAPI support
 #if CMK_CUDA
 #include "hapi.h"
+#endif 
+
 void CkHapiAddCallback(long stream, void (*cb)(void*, void*), int fid) 
 {
+  #if CMK_CUDA
   cudaStream_t stream_ptr = (cudaStream_t)stream;
   CkCallback callback(cb, (void *) fid);
   
   hapiAddCallback(stream_ptr, callback, NULL);
+  #else
+  // function must be defined regardless for cython compilation
+  CkAbort("CkHapiAddCallback> Charm++ was not built with CUDA support");
+  #endif
 }
-#endif // CMK_CUDA
 
-#endif
+#endif // CMK_CHARM4PY
 
 //------------------- Message Watcher (record/replay) ----------------
 


### PR DESCRIPTION
Due to the Charm4py cython compilation process, the HAPI functions used in Charm4py (right now, just CkHapiAddCallback) must be available regardless of charm++ build (even without cuda). With this change, the build succeeds regardless, but an error is thrown if the HAPI functions are used in Charm4py without the cuda build.