### PR TITLE
Revert "Fix Charm4py HAPI"

### DIFF
--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -511,7 +511,7 @@ extern void CkEnableTracing(int epIdx);
 extern void CkCallWhenIdle(int epIdx, void* obj);
 
 
-#if CMK_CHARM4PY
+#if CMK_CHARM4PY && CMK_CUDA
 extern void CkHapiAddCallback(long stream, void (*cb)(void*, void*), int fid);
 #endif
 

--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -2638,25 +2638,18 @@ void CkArrayExtSend_multi(int aid, int *idx, int ndims, int epIdx, int num_bufs,
 }
 
 
-// HAPI support
 #if CMK_CUDA
 #include "hapi.h"
-#endif 
-
 void CkHapiAddCallback(long stream, void (*cb)(void*, void*), int fid) 
 {
-  #if CMK_CUDA
   cudaStream_t stream_ptr = (cudaStream_t)stream;
   CkCallback callback(cb, (void *) fid);
   
   hapiAddCallback(stream_ptr, callback, NULL);
-  #else
-  // function must be defined regardless for cython compilation
-  CkAbort("CkHapiAddCallback> Charm++ was not built with CUDA support");
-  #endif
 }
+#endif // CMK_CUDA
 
-#endif // CMK_CHARM4PY
+#endif
 
 //------------------- Message Watcher (record/replay) ----------------
 


### PR DESCRIPTION
Reverts charmplusplus/charm#3889
Seems to not actually be needed? Charm4py builds and runs examples without error after adding a condition around the hapi call.