### PR TITLE
fix spack directory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -344,23 +344,23 @@ jobs:
         [[ $(uname) == "Linux" ]] && sudo apt-get install -y gfortran
 
         # Use this branch for testing, not main
-        sed -i -e 's,="main",="${{ github.head_ref }}",' var/spack/repos/builtin/packages/charmpp/package.py
+        sed -i -e 's,="main",="${{ github.head_ref }}",' var/spack/repos/spack_repo/builtin/packages/charmpp/package.py
 
         # Use a fork, not the main repo
         # If in merge_group mode, the branch should be created in the main repo
         if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-          sed -i -e 's,UIUC-PPL/charm.git,${{github.event.pull_request.head.repo.full_name}},' var/spack/repos/builtin/packages/charmpp/package.py
+          sed -i -e 's,UIUC-PPL/charm.git,${{github.event.pull_request.head.repo.full_name}},' var/spack/repos/spack_repo/builtin/packages/charmpp/package.py
         fi
 
         # Compile with debug symbols
-        sed -i -e 's,build(target,options.append("-g"); build(target,' var/spack/repos/builtin/packages/charmpp/package.py
+        sed -i -e 's,build(target,options.append("-g"); build(target,' var/spack/repos/spack_repo/builtin/packages/charmpp/package.py
 
         # Add +setcpuaffinity option to TESTOPTS
-        sed -i -e 's,\+\+local,++local +setcpuaffinity,' var/spack/repos/builtin/packages/charmpp/package.py
+        sed -i -e 's,\+\+local,++local +setcpuaffinity,' var/spack/repos/spack_repo/builtin/packages/charmpp/package.py
 
         # No need for automake/autoconf
-        sed -i -e '/automake/d' var/spack/repos/builtin/packages/charmpp/package.py
-        sed -i -e '/autoconf/d' var/spack/repos/builtin/packages/charmpp/package.py
+        sed -i -e '/automake/d' var/spack/repos/spack_repo/builtin/packages/charmpp/package.py
+        sed -i -e '/autoconf/d' var/spack/repos/spack_repo/builtin/packages/charmpp/package.py
 
     - name: Build Charm++
       run: |


### PR DESCRIPTION
2 weeks ago, Spack changed its directory structure, causing our spack_ubuntu-latest test to fail. This fixes that in ci.yaml.