### PR TITLE
bugfix: Fix SHMEM build error by fixing CmiAssert calls

### DIFF
--- a/src/conv-core/shmem/cmishmem.C
+++ b/src/conv-core/shmem/cmishmem.C
@@ -59,7 +59,7 @@ CmiIpcBlock* CmiMsgToIpcBlock(CmiIpcManager* manager, char* src, std::size_t len
     if (block == nullptr) {
       return nullptr;
     } else {
-      CmiAssertMsg((block->dst == manager->mine) && (manager->mine == CmiMyNode()));
+      CmiAssert((block->dst == manager->mine) && (manager->mine == CmiMyNode()));
       dst = (char*)CmiIpcBlockToMsg(block, true);
       memcpy(dst, src, len);
       CmiFree(src);
@@ -159,7 +159,7 @@ std::pair<CmiIpcBlock*, CmiIpcAllocStatus> CmiAllocIpcBlock(CmiIpcManager* meta,
 
 void CmiFreeIpcBlock(CmiIpcManager* meta, CmiIpcBlock* block) {
   auto bin = whichBin_(block->size);
-  CmiAssertMsg(bin < kNumCutOffPoints);
+  CmiAssert(bin < kNumCutOffPoints);
   auto& shared = meta->shared[block->src];
   auto& free = shared->free[bin];
   while (!pushBlock_(free, block->orig, shared))


### PR DESCRIPTION
Changes to the definition of CmiAssertMsg means that if you pass --enable-shmem as a build option, the build will fail because 2 calls to CmiAssertMsg in cmishmem.C don't actually have error messages. This fixes this by turning those calls into regular CmiAssert calls.