### PR TITLE
trace-summary: record message bytes per entry method per interval

### DIFF
--- a/src/ck-perf/trace-summary.C
+++ b/src/ck-perf/trace-summary.C
@@ -218,6 +218,7 @@ SumLogPool::~SumLogPool()
   delete[] epInfo;
   delete[] cpuTime;
   delete[] numExecutions;
+  delete[] msgBytes;
 }
 
 void SumLogPool::addEventType(int eventType, double time)
@@ -272,6 +273,7 @@ void SumLogPool::initMem()
 
    cpuTime = NULL;
    numExecutions = NULL;
+   msgBytes = NULL;
    if (sumDetail) {
        cpuTime = new double[poolSize*epInfoSize];
        _MEMCHECK(cpuTime);
@@ -279,6 +281,9 @@ void SumLogPool::initMem()
        numExecutions = new int[poolSize*epInfoSize];
        _MEMCHECK(numExecutions);
        memset(numExecutions, 0, poolSize*epInfoSize*sizeof(int));
+       msgBytes = new CmiUInt8[poolSize*epInfoSize];
+       _MEMCHECK(msgBytes);
+       memset(msgBytes, 0, poolSize*epInfoSize*sizeof(CmiUInt8));
 
 //         int i, e;
 //         for(i=0; i<poolSize; i++) {
@@ -453,6 +458,30 @@ void SumLogPool::write(void)
         }
         if (count > 1) fprintf(sdfp, "+%d", count);
         fprintf(sdfp, "\n");
+        // Write out msgBytes
+        // Run length encoding (RLE) along EP axis
+        fprintf(sdfp, "MsgBytesPerEPperInterval ");
+        CmiUInt8 lastBytes = getMsgBytes(0,0);
+        count=0;
+        fprintf(sdfp, "%llu", (unsigned long long)lastBytes);
+        for(e=0; e<_numEntries; e++) {
+            for(i=0; i<numBins; i++) {
+
+                CmiUInt8 u = getMsgBytes(i, e);
+                if (lastBytes == u) {
+                    count++;
+                } else {
+
+                    if (count > 1) fprintf(sdfp, "+%d", count);
+                    fprintf(sdfp, " %llu", (unsigned long long)u);
+                    lastBytes = u;
+                    count = 1;
+                }
+            }
+        }
+        if (count > 1) fprintf(sdfp, "+%d", count);
+        fprintf(sdfp, "\n");
+
         // Write out numExecutions
         // Run length encoding (RLE) along EP axis
         fprintf(sdfp, "EPCallTimePerInterval ");
@@ -525,7 +554,8 @@ void SumLogPool::setEp(int epidx, double time)
 
 // Called once from endExecute, endPack, etc. this function updates
 // the sumDetail intervals.
-void SumLogPool::updateSummaryDetail(int epIdx, double startTime, double endTime)
+void SumLogPool::updateSummaryDetail(int epIdx, double startTime, double endTime,
+                                     CmiUInt8 bytes)
 {
         if (epIdx >= epInfoSize) {
             CmiAbort("Too many entry points!!\n");
@@ -557,7 +587,10 @@ void SumLogPool::updateSummaryDetail(int epIdx, double startTime, double endTime
             CmiAbort("Error: end time of EP is less than start time\n");
         }
 
+        // startingBinIdx has been walked forward to the bin the execution ended
+        // in; count the message, and its size, where the run is counted.
         incNumExecutions(startingBinIdx, epIdx);
+        addToMsgBytes(startingBinIdx, epIdx, bytes);
 }
 
 // Shrinks pool[], cpuTime[], and numExecutions[]
@@ -576,12 +609,14 @@ void SumLogPool::shrink(void)
      for (int e=0; e < epInfoSize; e++) {
          setCPUtime(i, e, getCPUtime(i*2, e) + getCPUtime(i*2+1, e));
          setNumExecutions(i, e, getNumExecutions(i*2, e) + getNumExecutions(i*2+1, e));
+         setMsgBytes(i, e, getMsgBytes(i*2, e) + getMsgBytes(i*2+1, e));
      }
   }
   // zero out the remaining intervals
   if (sumDetail) {
     memset(&cpuTime[entries*epInfoSize], 0, (numBins-entries)*epInfoSize*sizeof(double));
     memset(&numExecutions[entries*epInfoSize], 0, (numBins-entries)*epInfoSize*sizeof(int));
+    memset(&msgBytes[entries*epInfoSize], 0, (numBins-entries)*epInfoSize*sizeof(CmiUInt8));
   }
   numBins = entries;
   CkpvAccess(binSize) *= 2;
@@ -647,6 +682,7 @@ TraceSummary::TraceSummary(char **argv):msgNum(0),binStart(0.0),idleStart(0.0),
   _logPool = new SumLogPool(CkpvAccess(traceRoot));
   // assume invalid entry point on start
   execEp=INVALIDEP;
+  execMsgBytes = 0;
   inIdle = 0;
   inExec = 0;
   depth = 0;
@@ -685,7 +721,9 @@ void TraceSummary::beginExecute(envelope *e, void *obj)
     beginExecute(-1,-1,_threadEP,-1);
   }
   else {
-    beginExecute(-1,-1,e->getEpIdx(),-1);
+    // the message length is passed on so that summary detail can record how
+    // many bytes an entry method received, not only how many messages
+    beginExecute(-1,-1,e->getEpIdx(),-1,e->getTotalsize());
   }  
 }
 
@@ -725,6 +763,7 @@ void TraceSummary::beginExecute(int event,int msgType,int ep,int srcPe, int mlen
 */
   
   execEp=ep;
+  execMsgBytes=(mlen > 0) ? (CmiUInt8)mlen : 0;
   double t = TraceTimer();
   //CmiPrintf("start: %f \n", start);
   
@@ -796,9 +835,10 @@ void TraceSummary::endExecute()
   binTime += t - ts;
 
   if (sumDetail && execEp >= 0 )
-      _logPool->updateSummaryDetail(execEp, start, t);
+      _logPool->updateSummaryDetail(execEp, start, t, execMsgBytes);
 
   execEp = INVALIDEP;
+  execMsgBytes = 0;
 }
 
 void TraceSummary::endExecute(char *msg){

--- a/src/ck-perf/trace-summary.h
+++ b/src/ck-perf/trace-summary.h
@@ -184,6 +184,12 @@ class SumLogPool {
     /// for Summary-Detail
     double *cpuTime;    //[MAX_INTERVALS * MAX_ENTRIES];
     int *numExecutions; //[MAX_INTERVALS * MAX_ENTRIES];
+    /** Bytes of the messages counted by numExecutions, so that a summary
+	trace can say how much data an entry method received and not only how
+	many messages. Only messages delivered to an entry method are counted;
+	packing and unpacking, which numExecutions also counts, contribute
+	none. */
+    CmiUInt8 *msgBytes; //[MAX_INTERVALS * MAX_ENTRIES];
 
   public:
     SumLogPool(char *pgm);
@@ -232,10 +238,18 @@ class SumLogPool {
     inline int incNumExecutions(unsigned int interval, unsigned int ep){
         ++numExecutions[interval*epInfoSize+ep];
         return numExecutions[interval*epInfoSize+ep]; }
+    inline CmiUInt8 getMsgBytes(unsigned int interval, unsigned int ep){
+        return msgBytes[interval*epInfoSize+ep]; }
+    inline void setMsgBytes(unsigned int interval, unsigned int ep, CmiUInt8 val){
+        msgBytes[interval*epInfoSize+ep] = val; }
+    inline CmiUInt8 addToMsgBytes(unsigned int interval, unsigned int ep, CmiUInt8 val){
+        msgBytes[interval*epInfoSize+ep] += val;
+        return msgBytes[interval*epInfoSize+ep]; }
     inline int getUtilization(int interval, int ep);
 
 
-    void updateSummaryDetail(int epIdx, double startTime, double endTime);
+    void updateSummaryDetail(int epIdx, double startTime, double endTime,
+                             CmiUInt8 bytes = 0);
 
 
 };
@@ -250,6 +264,7 @@ class TraceSummary : public Trace {
     int execEvent;
     int execEp;
     int execPe;
+    CmiUInt8 execMsgBytes; /* size of the message being executed, for summary detail */
     int msgNum; /* used to handle multiple endComputation calls?? */
 
     /* per-log metadata maintained to derive cross-event information */


### PR DESCRIPTION
A summary detail trace says how much time each entry method spent in an interval and how many times it ran there — which is how many messages it processed — but not how much data those messages carried. Projections can therefore show message counts over time for a summary trace but nothing about volume, while a `.log` trace gives both.

The size is already handed to the tracer and thrown away. `TraceSummary::beginExecute(int event, int msgType, int ep, int srcPe, int mlen, ...)` takes a length it never reads, and the envelope form drops it before calling that one:

```c
void TraceSummary::beginExecute(envelope *e, void *obj) {
  ...
  else beginExecute(-1,-1,e->getEpIdx(),-1);   // e->getTotalsize() discarded
```

### What this does

- passes the envelope's total size through, and remembers it for the matching `endExecute` the way `execEp` is remembered;
- accumulates it into a `msgBytes` array beside `numExecutions`, in the same bin the run is counted in, with the same allocation, `shrink()` and teardown;
- writes a `MsgBytesPerEPperInterval` line into the `.sumd` file in the same run length encoding as the two arrays already there.

Only messages delivered to an entry method contribute. Packing and unpacking, which `numExecutions` also counts because `updateSummaryDetail` is called for them from `endPack`/`endUnpack`, add no bytes.

The quantity recorded is `envelope::getTotalsize()`, which is exactly what `trace-projections` records as a message length, so byte figures from a summary trace and from a `.log` trace mean the same thing.

### Cost and compatibility

One 8 byte counter per bin per entry method while tracing, beside the 8 byte time and 4 byte count already kept, and one more line per processor in the `.sumd` file. Nothing changes when `+sumDetail` is off.

Readers that predate the new line are unaffected: Projections' `SumDetailReader` ignores labels it does not recognise, by explicit design ("this allows new formats to be implemented without immediately rendering this tool useless"), so an older Projections reads a newer `.sumd` unchanged. No file version bump is therefore needed. The Projections side that displays the new data is charmplusplus/projections#166.

### Testing

Built `netlrts-darwin-arm8` with `-DTRACING=1` on macOS (Apple clang 16) and ran a program that sends 100 messages to each of two entry methods, the second carrying twice the payload of the first. Envelope overhead is the same for both, so the difference between their recorded byte totals must be exactly 100 x payload:

```
small: 100 messages, expected 100   OK
large: 100 messages, expected 100   OK
bytes(large) - bytes(small) = 102400, expected 102400 (= 100 messages x 1024 extra bytes)   OK
implied envelope overhead: 112.0 bytes per message
```

(The payload has to be a multiple of the message alignment for that identity to hold — with a 1000 byte payload the two messages round to different padding and the difference is 800 short, which is alignment rather than accounting.)

Projections then read the same trace back and reported 113,600 bytes over 100 messages for one entry method and 216,000 over 100 for the other, matching the file. An existing 1920 processor trace written before this change still loads, with sizes reading zero throughout.

Not yet tested on a machine other than this laptop, or with reconverse.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)