### PR TITLE
Reduction fix for anytime migration (#3939), with heavy stress enabled

### DIFF
--- a/.github/workflows/reconverse-ci.yaml
+++ b/.github/workflows/reconverse-ci.yaml
@@ -125,16 +125,16 @@ jobs:
           make -C tests/charm++/anytime_bcastred CHARMC=$B/bin/charmc
           make -C tests/charm++/qd CHARMC=$B/bin/charmc
           make -C tests/charm++/megatest CHARMC=$B/bin/charmc
-      # NOTE: heavy migration configs (-m 1 -c 8) are enabled by the PR that
-      # lands the #3939 reduction fix -- they hang without it. Until then the
-      # stress tier runs the gentle shape.
+      # Heavy migration config (-m 1 -c 8): every step migrates 8 of the 8
+      # elements. Exercises the #3939 class (obligation-free PEs vs reduction
+      # tree) that this line's reduction fix closes; hangs without it.
       - name: anytime migration stress (single process)
         run: |
           set -e
           cd tests/charm++/anytime_bcastred
           B=$PWD/../../../reconverse-linux-x86_64
           for S in 1 2 3; do
-            env LD_LIBRARY_PATH=$B/lib ./bcastred +pe 4 -n 8 -i 500 -m 5 -c 1 -S $S -w 30
+            env LD_LIBRARY_PATH=$B/lib ./bcastred +pe 4 -n 8 -i 500 -m 1 -c 8 -S $S -w 30
           done
       - name: anytime migration stress (2 processes)
         run: |
@@ -142,7 +142,7 @@ jobs:
           cd tests/charm++/anytime_bcastred
           B=$PWD/../../../reconverse-linux-x86_64
           for S in 4 5; do
-            $B/_deps/lci-src/lcrun -n 2 env LD_LIBRARY_PATH=$B/lib ./bcastred +pe 4 -n 8 -i 500 -m 5 -c 1 -S $S -w 30
+            $B/_deps/lci-src/lcrun -n 2 env LD_LIBRARY_PATH=$B/lib ./bcastred +pe 4 -n 8 -i 500 -m 1 -c 8 -S $S -w 30
           done
       - name: qd + megatest multi-process
         run: |

--- a/src/ck-core/ckreduction.C
+++ b/src/ck-core/ckreduction.C
@@ -354,6 +354,32 @@ void CkReductionMgr::contributorDied(contributorInfo *ci)
     checkIsActive();
   }
   finishReduction();
+  maybeCompleteObligationFreeRound();  // same hole as migration (see below)
+}
+
+/* Anytime migration can leave this PE POPULATED BUT OBLIGATION-FREE for
+the current reduction: every local element that owed redNo migrated away
+before contributing, while every arrival already contributed to redNo
+elsewhere (each such arrival decrements adj(redNo).lcount, balancing its
+lcount++). Such a PE never starts the reduction on its own -- it gets no
+local contribution (addContribution is what normally calls
+startReduction), it may have no tree kids, and the parent's
+sendReductionStartingToKids pokes only kids on the inactiveList, which
+this PE never joined because lcount never reached 0. The subtree then
+never reports and the whole reduction hangs (issue #3939). When a
+migration event makes the current round's local requirement already
+satisfied, eagerly start and finish it (shipping the empty result up);
+a migrant that later owes this round contributes through the existing
+LateMigrantMsg path. lcount>0 keeps the barren case on the established
+inactive-list path. */
+void CkReductionMgr::maybeCompleteObligationFreeRound()
+{
+  if (!inProgress && !creating && lcount > 0 &&
+      nContrib >= lcount + adj(redNo).lcount) {
+    DEBR((AA "Migration left this PE obligation-free for #%d; completing it eagerly\n" AB,redNo));
+    startReduction(redNo, CkMyPe());
+    finishReduction();
+  }
 }
 
 //Migrating away (note that global count doesn't change)
@@ -370,6 +396,7 @@ void CkReductionMgr::contributorLeaving(contributorInfo *ci)
     checkIsActive();
   }
   finishReduction();
+  maybeCompleteObligationFreeRound();
 }
 
 //Migrating in (note that global count doesn't change)
@@ -390,6 +417,7 @@ void CkReductionMgr::contributorArriving(contributorInfo *ci)
   if (ci->redNo == redNo) {
     checkIsActive();
   }
+  maybeCompleteObligationFreeRound();
 }
 
 //Contribute-- the given msg can contain any data.  The reducerType
@@ -797,7 +825,8 @@ CkReductionMsg *CkReductionMgr::reduceMessages(CkMsgQ<CkReductionMsg> &msgs)
   // Copy message queue into msgArr, skipping placeholders:
   while (NULL!=(m=msgs.deq()))
   {
-    DEBR((AA "***** gcount=%d; sourceFlag=%d ismigratable %d \n" AB,m->gcount,m->nSources(),m->isMigratableContributor()));
+    // (static fn: AA/AB member context unavailable to DEBR)
+    DEBR(("Red PE%d> ***** gcount=%d; sourceFlag=%d ismigratable %d \n",CkMyPe(),m->gcount,m->nSources(),m->isMigratableContributor()));
     msgs_gcount+=m->gcount;
     if (m->sourceFlag!=0)
     { //This is a real message from an element, not just a placeholder

--- a/src/ck-core/ckreduction.h
+++ b/src/ck-core/ckreduction.h
@@ -702,6 +702,7 @@ private:
 	void startReduction(int number,int srcPE);
 	void addContribution(CkReductionMsg *m);
 	void finishReduction(void);
+  void maybeCompleteObligationFreeRound();
   void checkIsActive();
   void informParentInactive();
   void checkAndAddToInactiveList(int id, int red_no);

--- a/tests/charm++/anytime_bcastred/Makefile
+++ b/tests/charm++/anytime_bcastred/Makefile
@@ -11,6 +11,7 @@ bcastred.decl.h: bcastred.ci
 
 test: bcastred
 	$(call run, +p2 ./bcastred)
+	$(call run, +p2 ./bcastred -n 8 -i 200 -m 1 -c 8 )
 
 clean:
 	rm -rf *.decl.h *.def.h bcastred charmrun


### PR DESCRIPTION
Cherry-pick of the #3939 fix from #3942 (obligation-free PEs created by anytime migration stall the reduction tree; the fix completes such rounds eagerly in contributorLeaving/Arriving/Died), plus the enablement it unlocks: bcastred's `make test` gains the heavy shape and the stress job's three seeds flip from gentle (-m 5 -c 1) to heavy (-m 1 -c 8, all 8 elements migrating every step).

**The PR proves itself**: the heavy configurations hang without the first commit — every platform job now runs them in both process shapes, and the stress job runs them on the error-checking build. Validated locally on reconverse-darwin-arm8 before pushing (200-step and 500-step heavy runs, 1k and 2.6k migrations, single- and 2-process lcrun).

Classic-side evidence (this line's CI is reconverse-only): the identical fix commit has the full classic matrix green on #3942 against main.

Plan item 5. Item 6 (#3943 record-replay) follows; #3942 itself remains open against main for the freeze-tag line (plan item 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)