### PR TITLE
Restore classic token-pool registration under a proper guard

### DIFF
--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -1484,7 +1484,9 @@ void CkUnpackMessage(envelope **pEnv)
 #if CMK_OBJECT_QUEUE_AVAILABLE
 static int index_objectQHandler;
 #endif
-//int index_tokenHandler;
+#if !CMK_RECONVERSE  /* token pool lives in ckobjQ.C, classic-only */
+int index_tokenHandler;
+#endif
 int index_skipCldHandler;
 
 void _skipCldHandler(void *converseMsg)
@@ -2137,9 +2139,11 @@ void _ckModuleInit(void) {
 #if CMK_OBJECT_QUEUE_AVAILABLE
 	CmiAssignOnce(&index_objectQHandler, CkRegisterHandler(_ObjectQHandler));
 #endif
-	//CmiAssignOnce(&index_tokenHandler, CkRegisterHandler(_TokenHandler));
-	//CkpvInitialize(TokenPool*, _tokenPool);
-	//CkpvAccess(_tokenPool) = new TokenPool;
+#if !CMK_RECONVERSE  /* _TokenHandler/TokenPool live in ckobjQ.C, classic-only */
+	CmiAssignOnce(&index_tokenHandler, CkRegisterHandler(_TokenHandler));
+	CkpvInitialize(TokenPool*, _tokenPool);
+	CkpvAccess(_tokenPool) = new TokenPool;
+#endif
 }
 
 


### PR DESCRIPTION
While preparing plan item 6, I found the #3943 record-replay repairs are **already on this line** — they rode in with #3944's ck.C graft (verified: the recorder's CRC-gated pack, the broadcast bounce set, flushLog durability, and truncated-log handling are all present). Item 6 is therefore done by subsumption, and #3943 remains open purely as the classic-main vehicle for the freeze tag (plan item 8).

The comparison flushed out the one remaining real ck.C divergence: the branch had commented out `index_tokenHandler` and the `_TokenHandler`/`TokenPool` registration because their home (`ckobjQ.C`) is classic-only — disabling them on classic as collateral (a latent break for object-queue configurations). This PR replaces the comment-out with `#if !CMK_RECONVERSE`, restoring mainline behavior verbatim on classic.

Validated: both runtimes build clean locally; `index_tokenHandler` is back in classic's libck and absent from reconverse's, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)