### PR TITLE
ci.yaml: upgrade actions off deprecated Node 20 runtimes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Run build
       run: ./buildold all-test netlrts-linux-x86_64 -g -j4 --with-production
     - name: test
@@ -26,7 +26,7 @@ jobs:
   changa_netlrts-linux-x86_64:
     runs-on: ubuntu-latest 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: build-charm++
       run: ./build ChaNGa netlrts-linux-x86_64 -g -j4 --with-production
     - name: build-changa
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: build
       run: |
         sudo apt-get update
@@ -59,9 +59,8 @@ jobs:
   doc:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    -
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install prerequisites
@@ -75,7 +74,7 @@ jobs:
     timeout-minutes: 90
     runs-on: ubuntu-22.04  #  ubuntu-latest does not work
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: install-prerequisites
       run: sudo apt-get update && sudo apt-get install -y mpich libmpich-dev
     - name: build
@@ -91,7 +90,7 @@ jobs:
     timeout-minutes: 90
     runs-on: ubuntu-22.04  #  ubuntu-latest does not work
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: install-prerequisites
       run: sudo apt-get update && sudo apt-get install -y mpich libmpich-dev
     - name: build
@@ -103,7 +102,7 @@ jobs:
     timeout-minutes: 60
     runs-on: macos-15-intel
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: build-only
       run: ./build LIBS multicore-darwin-x86_64 -g -j3 --with-production --enable-tracing
 #    - name: test
@@ -125,7 +124,7 @@ jobs:
   #   timeout-minutes: 60
   #   runs-on: macos-latest
   #   steps:
-  #   - uses: actions/checkout@v4
+  #   - uses: actions/checkout@v5
   #   - name: build
   #     run: ./build LIBS multicore-darwin-arm8 -g -j3 --with-production --enable-tracing
   #   - name: test
@@ -150,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: install-prerequisites
       if: ${{ env.namd_secret != '' }}
       run: |
@@ -179,7 +178,7 @@ jobs:
     - name: Cache apoa1 files
       if: ${{ env.namd_secret != '' }}
       id: cache-apoa1-files
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ~/namddata/apoa1
         key: namd-apoa1-files
@@ -205,7 +204,7 @@ jobs:
     timeout-minutes: 60
     runs-on: macos-15-intel
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: build-only
       run: ./build all-test netlrts-darwin-x86_64 --build-shared --with-production --enable-error-checking --enable-lbuserdata -j3 -g -Werror=vla
       # TODO: this should build tests with "-charm-shared". See #2735 on why this is not done currently.
@@ -219,7 +218,7 @@ jobs:
   #   timeout-minutes: 60
   #   runs-on: macos-latest
   #   steps:
-  #   - uses: actions/checkout@v4
+  #   - uses: actions/checkout@v5
   #   - name: build
   #     run: ./build all-test netlrts-darwin-arm8 --build-shared --with-production --enable-error-checking --enable-lbuserdata -j3 -g -Werror=vla
   #     # TODO: this should build tests with "-charm-shared". See #2735 on why this is not done currently.
@@ -232,7 +231,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: install-prerequisites
       run: |
         sudo dpkg --add-architecture i386
@@ -250,7 +249,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: build
       run: ./build all-test netlrts-linux-x86_64 --with-production --enable-error-checking --enable-lbuserdata -j3 -g -Werror=vla
       # TODO: this should build tests with "-charm-shared". See #2735 on why this is not done currently.
@@ -263,7 +262,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: build
       run: ./build all-test netlrts-linux-x86_64 smp --with-production --enable-error-checking --enable-lbuserdata -j3 -g -Werror=vla
       # TODO: this should build tests with "-charm-shared". See #2735 on why this is not done currently.
@@ -276,7 +275,7 @@ jobs:
     timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: build
       run: ./build all-test netlrts-linux-x86_64 syncft -j2 -g
     - name: test
@@ -288,7 +287,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: ShellCheck
       run: |
         # TODO: add more scripts
@@ -307,7 +306,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install Spack
       run: |
         pwd
@@ -353,13 +352,13 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v5
     # Uncomment the lines below to set up a tmate session for debugging.
     # See https://github.com/marketplace/actions/debugging-with-tmate for details.
     # This can't be enabled all the time as the tmate session will wait for a user to connect before running
     # the build.
     #- name: Tmate session for debugging
-    #  uses: mxschmitt/action-tmate@v2
+    #  uses: mxschmitt/action-tmate@v3
     - name: install-prerequisites
       run: |
         sudo apt-get update
@@ -398,7 +397,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: install-prerequisites
       run: |
         sudo apt-get update
@@ -426,7 +425,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-24.04-arm
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: build
       run: ./build all-test netlrts-linux-arm8 --with-production --enable-error-checking --enable-lbuserdata -j4 -g -Werror=vla
     - name: test
@@ -438,7 +437,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-24.04-arm
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: build
       run: ./build all-test netlrts-linux-arm8 smp --with-production --enable-error-checking --enable-lbuserdata -j4 -g -Werror=vla
     - name: test
@@ -453,7 +452,7 @@ jobs:
       # The runner has 4 vCPUs; let Open MPI oversubscribe for wider test shapes.
       OMPI_MCA_rmaps_base_oversubscribe: "true"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: install-prerequisites
       # openmpi, as the retired CircleCI job used: Ubuntu 24.04's mpich is
       # built on the ch4:ucx device, which crashes at startup on these runners.
@@ -474,7 +473,7 @@ jobs:
         shell: msys2 {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64


### PR DESCRIPTION
Extraction of Ritvik's CI modernization from the gpu-stage1-hapi branch (his authorship preserved on the commit), targeted where it has lasting effect: classic main. Action upgrades only — checkout v5, setup-python v6, cache v5, tmate v3; no job or trigger changes (main keeps `on: [pull_request, merge_group]`; the reviewed line's trigger restriction was deliberately not imported).

Context: on the reviewed reconverse line this file never executes (trigger restricted to PRs targeting main) and plan item 21 deletes it there before the branch rename — so these upgrades only persist via main, where they'll ride into the `classic` branch at the rename.

Requested by Ritvik via Kale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)