### PR TITLE
Bump the reconverse pin to main (0673ee8)

### DIFF
--- a/cmake/fetch_reconverse/CMakeLists.txt
+++ b/cmake/fetch_reconverse/CMakeLists.txt
@@ -14,7 +14,7 @@ set_directory_properties(PROPERTIES
 # this SHA in a reviewed commit; --with-fetch-reconverse-tag/-dir still
 # override for development.
 set(AUTOFETCH_RECONVERSE_TAG
-    f3f411072bc9790232c42e22782191ba83749ba6
+    0673ee82ab71fee347536691e2c781df99b2ba6d
     CACHE STRING "The reconverse commit (full SHA) to fetch")
 
 include(FetchContent)


### PR DESCRIPTION
Routine pin bump. Moves `AUTOFETCH_RECONVERSE_TAG` to reconverse main, which now carries #211 (`CmiNodeRankOnPhysicalNode()`) along with everything merged there since `f3f4110`.

Per the pinning policy: reconverse is consumed by SHA so that a given charm commit always builds the same dependency and CI results stay reproducible; bumps are deliberate, and this PR's own CI run is the integration test for the new reconverse version across the full tier.

Follow-up, separately: the GPU code drops its two copies of the node-rank formula in favour of the new query (branch `node-rank-single-source`, which also needs #3955 for the second copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)