### PR TITLE
Bump reconverse pin to 2c50813e7 (cpuaffinity startup-hang fix)

### DIFF
--- a/cmake/fetch_reconverse/CMakeLists.txt
+++ b/cmake/fetch_reconverse/CMakeLists.txt
@@ -14,7 +14,7 @@ set_directory_properties(PROPERTIES
 # this SHA in a reviewed commit; --with-fetch-reconverse-tag/-dir still
 # override for development.
 set(AUTOFETCH_RECONVERSE_TAG
-    0673ee82ab71fee347536691e2c781df99b2ba6d
+    2c50813e71e23e5f8aec5a258c4c35e898f7144f
     CACHE STRING "The reconverse commit (full SHA) to fetch")
 
 include(FetchContent)


### PR DESCRIPTION
Picks up [charmplusplus/reconverse#212](https://github.com/charmplusplus/reconverse/pull/212), merged today. Range `0673ee8..2c50813` is that one commit.

## Why this pin bump is not routine

#212 fixes a **startup hang**, not a performance problem. `CmiCheckAffinity` had PE 0 wait unconditionally whenever `CmiNumPes() > 1`, while the only PEs that send are those with `CmiPhysicalNodeID(pe) == 0`, and the flag PE 0 waits on is set in exactly one place — the receive handler. With one PE on physical node 0 there is no sender, the handler never runs, and PE 0 spins forever, before any application code executes.

The shape that triggers it is an ordinary multi-node launch:

```
srun --mpi=pmi2 -N2 -n2 ./app +pe 2
```

So until this pin moves, every charm build fetches a reconverse that cannot run one PE per physical node. It is CPU-only code — no GPU, no HAPI, no D2D — so it strands plain jobs, and it presents as a walltime kill with nothing after `cpu topology info is gathered`, which reads as a machine or queue problem rather than a bug.

## Verification

On Anvil (InfiniBand, `srun --mpi=pmi2`), patched and unpatched built from the same tree and run in the same job on the same two nodes:

| shape | PEs on phys node 0 | before | after |
|---|---|---|---|
| `-N2 -n2 +pe 2` | **1** | **hang (killed at 120 s)** | **pass** |
| `-N2 -n2 -c 2 +pe 4` | 2 | pass | pass |
| `-N2 -n4 +pe 4` | 2 | pass | pass |
| `-N1 -n2 +pe 2` | 2 | pass | pass |

Both `benchmarks/charm++/pingpong` and `megatest` go from hang to pass in the one-PE-per-node shape; the ≥2-PE shapes and the single-node control are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)