### PR TITLE
Device zerocopy: registered device pool (arenas registered lazily on first network use)

### DIFF
--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -9416,6 +9416,32 @@ declare the target entry method to take a message (for example
 ``CkCallback::setRefnum``; a zero-argument entry method cannot be matched by
 reference number.
 
+A registered device pool
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Device buffers can also be taken from a pool the runtime registers for you:
+
+.. code-block:: c++
+
+   double* buf = (double*)CkDeviceMalloc(bytes);
+   ...
+   CkDeviceFree(buf);
+
+The pool hands out buffers from arenas, large device allocations grown on
+demand (``CK_GPU_ARENA_MB`` in the environment sets the arena size, default
+256). An arena is registered with the network the first time a buffer in it
+is sent or received into, whole, and stays registered; arenas whose buffers
+never cross the network are never registered. Buffers from the pool need no
+``CkDeviceBufferRegister`` call and no release per message, and a process
+sending from many such buffers holds one registration per arena rather than
+one per buffer, which measured faster than registering each buffer
+explicitly. The pool owns the arena, so freeing and reallocating pool buffers
+is safe with respect to registration.
+
+The pool answers the registration question only. When a send buffer may be
+overwritten is still decided by the callback on ``CkDeviceBuffer`` or by
+alternating between two buffers, as described above.
+
 For non-UCX builds, a more optimized mechanism for inter-process communication using CUDA IPC, POSIX shared memory,
 and pre-allocated GPU communication buffers are available through runtime flags.
 This significantly reduces the overhead from creating and opening device IPC handles,

--- a/src/ck-core/ckrdmadevice.C
+++ b/src/ck-core/ckrdmadevice.C
@@ -605,34 +605,56 @@ extern "C" {
   int device_dereg_handler;
 }
 
-/* Persistent device-buffer registration (fix (b) for #3960).
+/* Persistent device-buffer registration (fix (b) for #3960), and a
+ * registered device pool.
  *
- * Registered regions live in one interval map per process: [start, end)
- * with the layer's memory-region handle.  CkDeviceBufferRegister(ptr, cnt)
- * registers a buffer the application allocated itself, once (a whole array
- * may be registered and sub-ranges of it sent or posted);
- * CkDeviceBufferDeregister releases it before the application frees it.
+ * Registered REGIONS live in one interval map per process: [start, end)
+ * with the layer's memory-region handle.  Two ways in:
+ *   - CkDeviceBufferRegister(ptr, cnt): the application registers a buffer
+ *     it allocated itself, once; CkDeviceBufferDeregister before freeing.
+ *   - CkDeviceMalloc(size) / CkDeviceFree(ptr): a device pool of arenas
+ *     (buddy allocator over one large device allocation each, grown on
+ *     demand).  An arena is registered LAZILY, whole, on the first send or
+ *     receive post that lands in it, so arenas that never cross the network
+ *     are never pinned.  The pool owns the arena's lifetime, which is what
+ *     makes the registration safe without allocator hooks.
  * The send path (CkRdmaDeviceOnSender) and the receive path
  * (CkRdmaDeviceIssueRgets) look a buffer up by range containment; a hit
  * reuses the region's handle and marks the buffer NODEREG so the
  * completion-time release above leaves it alone; a miss falls back to the
- * per-message registration that fix (a) releases.  The lifetime is the
- * application's, explicitly: no allocator hooks, no cache eviction, and an
- * unregistered buffer stays correct, only slower. */
+ * per-message registration that fix (a) releases.  Sweeping idle arenas is
+ * deliberately not done here (idle-time / load-balancing-time work, later). */
 #include <mutex>
 #include <map>
 #include <vector>
+#include "buddy_allocator.h"
 
-struct DeviceRegion { uintptr_t end; char layerInfo[CMK_NOCOPY_DIRECT_BYTES]; };
+struct DeviceRegion { uintptr_t end; bool arena; char layerInfo[CMK_NOCOPY_DIRECT_BYTES]; };
+struct DeviceArena { buddy::allocator* alloc; uintptr_t start, end; bool registered; };
 static std::map<uintptr_t, DeviceRegion> device_regions;   // start -> region
+static std::vector<DeviceArena> device_arenas;
 static std::mutex device_reg_mutex;
 
-// Under device_reg_mutex.
+// Under device_reg_mutex.  Registers the arena on first use.
 static const DeviceRegion* deviceRegionFind(uintptr_t p, size_t cnt) {
   auto it = device_regions.upper_bound(p);
   if (it != device_regions.begin()) {
     --it;
     if (p >= it->first && p + cnt <= it->second.end) return &it->second;
+  }
+  for (auto& ar : device_arenas) {
+    if (p >= ar.start && p + cnt <= ar.end) {
+      if (!ar.registered) {
+        DeviceRegion r; r.end = ar.end; r.arena = true;
+        CmiSetRdmaBufferInfo(r.layerInfo, (const void*)ar.start, ar.end - ar.start, CMK_BUFFER_REG);
+        ar.registered = true;
+        if (CkMyPe() == 0)
+          CmiPrintf("CkRdmaDevice> device pool arena at %p (%zu MB) registered on first use\n",
+                    (void*)ar.start, (size_t)((ar.end - ar.start) >> 20));
+        return &device_regions.emplace(ar.start, r).first->second;
+      }
+      return nullptr;  // registered arena is in the map; containment failed, so the range straddles
+    }
   }
   return nullptr;
 }
@@ -640,10 +662,10 @@ static const DeviceRegion* deviceRegionFind(uintptr_t p, size_t cnt) {
 void CkDeviceBufferRegister(const void* ptr, size_t cnt) {
   uintptr_t p = (uintptr_t)ptr;
   std::lock_guard<std::mutex> g(device_reg_mutex);
-  if (deviceRegionFind(p, cnt)) return;  // already covered
+  if (deviceRegionFind(p, cnt)) return;  // already covered (explicit or arena)
   if (device_regions.empty() && CkMyPe() == 0)
     CmiPrintf("CkRdmaDevice> persistent device-buffer registration in use (CkDeviceBufferRegister)\n");
-  DeviceRegion r; r.end = p + cnt;
+  DeviceRegion r; r.end = p + cnt; r.arena = false;
   CmiSetRdmaBufferInfo(r.layerInfo, ptr, cnt, CMK_BUFFER_REG);
   device_regions.emplace(p, r);
 }
@@ -651,9 +673,46 @@ void CkDeviceBufferRegister(const void* ptr, size_t cnt) {
 void CkDeviceBufferDeregister(const void* ptr, size_t cnt) {
   std::lock_guard<std::mutex> g(device_reg_mutex);
   auto it = device_regions.find((uintptr_t)ptr);
-  if (it == device_regions.end()) return;
+  if (it == device_regions.end() || it->second.arena) return;
   CmiDeregisterMem(ptr, it->second.layerInfo, CkMyPe(), CMK_BUFFER_REG);
   device_regions.erase(it);
+}
+
+static size_t deviceArenaBytes() {
+  static size_t bytes = 0;
+  if (!bytes) {
+    const char* e = getenv("CK_GPU_ARENA_MB");
+    bytes = (size_t)(e ? atol(e) : 256) << 20;
+  }
+  return bytes;
+}
+
+void* CkDeviceMalloc(size_t size) {
+  std::lock_guard<std::mutex> g(device_reg_mutex);
+  for (auto& ar : device_arenas) {
+    void* q = ar.alloc->malloc(size, true);
+    if (q) return q;
+  }
+  size_t bytes = deviceArenaBytes();
+  while (bytes < size * 2) bytes <<= 1;
+  DeviceArena ar;
+  ar.alloc = new buddy::allocator(bytes, bytes);
+  ar.start = (uintptr_t)ar.alloc->base_ptr; ar.end = ar.start + bytes; ar.registered = false;
+  device_arenas.push_back(ar);
+  if (CkMyPe() == 0)
+    CmiPrintf("CkRdmaDevice> device pool: arena %zu of %zu MB at %p (CK_GPU_ARENA_MB)\n",
+              device_arenas.size(), bytes >> 20, (void*)ar.start);
+  void* q = ar.alloc->malloc(size, true);
+  if (!q) CkAbort("CkDeviceMalloc: request larger than a fresh arena");
+  return q;
+}
+
+void CkDeviceFree(void* ptr) {
+  uintptr_t p = (uintptr_t)ptr;
+  std::lock_guard<std::mutex> g(device_reg_mutex);
+  for (auto& ar : device_arenas)
+    if (p >= ar.start && p < ar.end) { ar.alloc->free(ptr); return; }
+  CkAbort("CkDeviceFree: pointer is not from the device pool");
 }
 
 // Initialise 'b' for ptr/cnt: from a registered region if one covers it

--- a/src/ck-core/ckrdmadevice.h
+++ b/src/ck-core/ckrdmadevice.h
@@ -162,6 +162,9 @@ extern "C" {
 // when the application frees the buffer.  Exact (pointer, length) match.
 void CkDeviceBufferRegister(const void* ptr, size_t cnt);
 void CkDeviceBufferDeregister(const void* ptr, size_t cnt);
+// Device pool: arenas registered lazily, whole, on first network use.
+void* CkDeviceMalloc(size_t size);
+void CkDeviceFree(void* ptr);
 // Per-PE init of the device zerocopy path (idle-time ack flush).
 void CkRdmaDeviceInit();
 


### PR DESCRIPTION
On top of #3961 (the #3960 fix); one commit.

## What

`CkDeviceMalloc(size)` / `CkDeviceFree(ptr)`: device buffers from arenas, one large device allocation each, managed by the buddy allocator that already backs the device communication buffer (`buddy_allocator.h`), grown on demand (`CK_GPU_ARENA_MB`, default 256). What is new is the arenas, their registration, and this public surface. An arena is registered lazily, whole, on the first send or receive post that lands in it, through the same interval map `CkDeviceBufferRegister` uses, so arenas that never cross the network are never pinned. The pool owns the arena's lifetime, which is what makes the registration safe without allocator hooks. A buffer that straddles two arenas falls back to per-message registration.

## What it does not answer

The pool answers the registration question, not the overwrite question. When a sender may reuse a buffer is still what the source callback on `CkDeviceBuffer` is for, or double-buffering: a neighbour that has sent its message i+1 has finished reading buffer i. No shipped example passes a source callback today (separate issue), and the pool makes that more important, not less, because it removes the one other signal that used to arrive.

## Measured

Same setup as #3961, one allocation, two reps, `avg_iter_us`:

| | 32 chares/GCD | 2 chares/GCD | fixed protocol (one stream, stream-ordered delivery) |
|---|---|---|---|
| fix (a), piggybacked release | 4225 / 4228 | 272.5 / 273.4 | |
| explicit `CkDeviceBufferRegister` | 4122 / 4123 | 263.3 / 262.2 | 2058 / 2067 |
| pool, no application calls | **4059 / 4039** | **257.8 / 258.3** | **1982 / 1989** |

2% faster than explicit per-buffer registration (one memory region per process instead of eight per chare), 4-5% faster than per-message registration with piggybacked release, with no registration call in the application; 15,000 iterations on one registration.

## Left for later

Sweeping idle arenas (idle or load-balancing time), releasing arenas at exit, a per-device arena set for processes that drive more than one device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B3dZrnTsqMkWjs9CXMFs4
